### PR TITLE
Switch from `sentry-raven` to `sentry-ruby`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ $ RSPECQ_BUILD=123 RSPECQ_WORKDER=foo1 rspecq spec/
 
 RSpecQ can optionally emit build events to a
 [Sentry](https://sentry.io) project by setting the
-[`SENTRY_DSN`](https://github.com/getsentry/raven-ruby#raven-only-runs-when-sentry_dsn-is-set)
-environment variable.
+`SENTRY_DSN` environment variable.
 
 This is convenient for monitoring important warnings/errors that may impact
 build times, such as the fact that no previous timings were found and

--- a/bin/rspecq
+++ b/bin/rspecq
@@ -3,6 +3,8 @@ require "rspecq"
 
 config = RSpecQ::Configuration.new(ARGV)
 
+Sentry.init if ENV['SENTRY_DSN']
+
 if config.report?
   reporter = RSpecQ::Reporter.new(
     build_id: config.build,

--- a/lib/rspecq.rb
+++ b/lib/rspecq.rb
@@ -1,5 +1,5 @@
 require "rspec/core"
-require "sentry-raven"
+require "sentry-ruby"
 
 module RSpecQ
   # If a worker haven't executed an example for more than WORKER_LIVENESS_SEC

--- a/lib/rspecq/reporter.rb
+++ b/lib/rspecq/reporter.rb
@@ -150,7 +150,7 @@ module RSpecQ
           spec_file: filename
         }
 
-        Raven.capture_message(
+        Sentry.capture_message(
           "Flaky test in #{filename}",
           level: "warning",
           extra: extra,

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -296,7 +296,7 @@ module RSpecQ
     def log_event(msg, level, additional = {})
       puts msg
 
-      Raven.capture_message(msg, level: level, extra: {
+      Sentry.capture_message(msg, level: level, extra: {
         build: @build_id,
         worker: @worker_id,
         queue: queue.inspect,

--- a/rspecq.gemspec
+++ b/rspecq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "redis"
-  s.add_dependency "sentry-raven"
+  s.add_dependency "sentry-ruby"
   s.add_dependency "rspec_junit_formatter"
 
   s.add_development_dependency "minitest"


### PR DESCRIPTION
This is the same as previously merged in #2, but this hasn't made it to this new branch yet.