### PR TITLE
Add time-balanced chunk splitting for slow spec files

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -27,6 +27,7 @@ else
   worker.rspec_args = config.rspec_args
   worker.populate_timings = config.timings
   worker.file_split_threshold = config.file_split_threshold
+  worker.chunk_target_duration = config.chunk_target_duration
   worker.max_requeues = config.max_requeues
   worker.queue_wait_timeout = config.queue_wait_timeout
   worker.fail_fast = config.fail_fast

--- a/lib/rspecq/configuration.rb
+++ b/lib/rspecq/configuration.rb
@@ -8,6 +8,7 @@ module RSpecQ
   # for rspec.
   Configuration = Struct.new(
     :build,
+    :chunk_target_duration,
     :exclude_pattern,
     :fail_fast,
     :files_or_dirs_to_run,

--- a/lib/rspecq/formatters/job_timing_recorder.rb
+++ b/lib/rspecq/formatters/job_timing_recorder.rb
@@ -10,7 +10,13 @@ module RSpecQ
       end
 
       def dump_summary(summary)
-        @queue.record_timing(@job, Float(summary.duration))
+        if @job.include?("+")
+          summary.examples.each do |example|
+            @queue.record_timing(example.id, Float(example.execution_result.run_time))
+          end
+        else
+          @queue.record_timing(@job, Float(summary.duration))
+        end
       end
     end
   end

--- a/lib/rspecq/parser.rb
+++ b/lib/rspecq/parser.rb
@@ -95,6 +95,13 @@ module RSpecQ
           opts[:file_split_threshold] = v
         end
 
+        o.on("--chunk-target-duration N", Integer, "Target duration in seconds for " \
+                                                   "time-balanced example chunks when splitting slow files " \
+                                                   "(default: 30). Groups examples into chunks of approximately " \
+                                                   "this duration to reduce Kernel.load overhead.") do |v|
+          opts[:chunk_target_duration] = v
+        end
+
         o.on("--report", "Enable reporter mode: do not pull tests off the queue; " \
                          "instead print build progress and exit when it's " \
                          "finished.\n#{o.summary_indent * 9} " \
@@ -182,6 +189,7 @@ module RSpecQ
       opts[:include_pattern] ||= ENV["INCLUDE_PATTERN"]
       opts[:exclude_pattern] ||= ENV["EXCLUDE_PATTERN"]
       opts[:worker_liveness_sec] ||= Integer(ENV["RSPECQ_WORKER_LIVENESS_SEC"] || DEFAULT_WORKER_LIVENESS_SEC)
+      opts[:chunk_target_duration] ||= Integer(ENV["RSPECQ_CHUNK_TARGET_DURATION"] || 30)
     end
 
     def env_set?(var)

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -116,6 +116,20 @@ module RSpecQ
       )
     end
 
+    # If this worker has a job in the running hash (from a previous crash),
+    # put it back on the queue. This must be called before update_heartbeat
+    # or reserve_job when a worker restarts with the same worker_id.
+    def recover_own_job
+      job = @redis.hget(key_queue_running, @worker_id)
+      return nil unless job
+
+      @redis.multi do |pipeline|
+        pipeline.lpush(key_queue_unprocessed, job)
+        pipeline.hdel(key_queue_running, @worker_id)
+      end
+      job
+    end
+
     def requeue_lost_job
       @redis.eval(
         REQUEUE_LOST_JOB,

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -71,6 +71,13 @@ module RSpecQ
     # Defaults to nil
     attr_accessor :rspec_args
 
+    # Target duration in seconds for time-balanced example chunks.
+    # When splitting slow files, examples are grouped into chunks of
+    # approximately this duration to reduce Kernel.load calls.
+    #
+    # Defaults to 30
+    attr_accessor :chunk_target_duration
+
     attr_reader :queue
 
     def initialize(build_id:, worker_id:, redis_opts:, worker_liveness_sec:)
@@ -89,6 +96,7 @@ module RSpecQ
       @seed = srand && (srand % 0xFFFF)
       @reproduction = false
       @junit_output = nil
+      @chunk_target_duration = 30
 
       RSpec::Core::Formatters.register(Formatters::JobTimingRecorder, :dump_summary)
       RSpec::Core::Formatters.register(Formatters::ExampleCountRecorder, :dump_summary)
@@ -99,6 +107,12 @@ module RSpecQ
 
     def work
       puts "Working for build #{@build_id} (worker=#{@worker_id})"
+
+      # If this worker crashed previously (OOM kill, etc.), it may have a job
+      # stuck in the running hash. Recover it before doing anything else —
+      # otherwise reserve_job will silently overwrite it.
+      recovered = queue.recover_own_job
+      puts "Recovered abandoned job from previous crash: #{recovered}" if recovered
 
       try_publish_queue!(queue)
       queue.wait_until_published(queue_wait_timeout)
@@ -151,7 +165,7 @@ module RSpecQ
           RSpec.configuration.add_formatter(Formatters::JobTimingRecorder.new(queue, job))
         end
 
-        args = [*rspec_args, "--format", "progress", job]
+        args = [*rspec_args, "--format", "progress", *job.split("+")]
         opts = RSpec::Core::ConfigurationOptions.new(args)
 
         _result = RSpec::Core::Runner.new(opts).run($stderr, $stdout)
@@ -206,7 +220,9 @@ module RSpecQ
 
       if slow_files.any?
         jobs.concat(files_to_run - slow_files)
-        jobs.concat(files_to_example_ids(slow_files))
+        example_ids = files_to_example_ids(slow_files)
+        chunks = build_time_balanced_chunks(example_ids, timings, chunk_target_duration)
+        jobs.concat(chunks)
       else
         jobs.concat(files_to_run)
       end
@@ -215,11 +231,17 @@ module RSpecQ
 
       # assign timings (based on previous runs) to all jobs
       jobs = jobs.each_with_object({}) do |j, h|
-        puts "Untimed job: #{j}" if timings[j].nil?
+        if j.include?("+")
+          # Chunk job: sum per-example timings (or estimate from default)
+          parts = j.split("+")
+          h[j] = parts.sum { |p| timings[p] || default_timing }
+        else
+          puts "Untimed job: #{j}" if timings[j].nil?
 
-        # HEURISTIC: put jobs without previous timings (e.g. a newly added
-        # spec file) in the middle of the queue
-        h[j] = timings[j] || default_timing
+          # HEURISTIC: put jobs without previous timings (e.g. a newly added
+          # spec file) in the middle of the queue
+          h[j] = timings[j] || default_timing
+        end
       end
 
       # sort jobs based on their timings (slowest to be processed first)
@@ -229,6 +251,42 @@ module RSpecQ
     end
 
     private
+
+    # Groups example IDs into time-balanced chunks, one chunk per Kernel.load.
+    # Examples from different files are never mixed. Uses per-example timings
+    # from Redis when available; falls back to file_timing / example_count.
+    #
+    # Returns an array of job strings: single examples are bare IDs, multi-example
+    # chunks are "+"-delimited (e.g. "spec/foo.rb[1:1]+spec/foo.rb[1:2]").
+    def build_time_balanced_chunks(example_ids, timings, target_duration)
+      by_file = example_ids.group_by { |id| id.sub(/\[.*\]$/, "") }
+      chunks = []
+
+      by_file.each do |file, ids|
+        file_timing = timings[file]
+        default_example_timing = file_timing ? file_timing / ids.size : target_duration / 10.0
+
+        timed_ids = ids.map { |id| [id, timings[id] || default_example_timing] }
+        timed_ids.sort_by! { |_, t| -t }
+
+        current_chunk = []
+        current_duration = 0.0
+
+        timed_ids.each do |id, duration|
+          if current_chunk.empty? || current_duration + duration <= target_duration
+            current_chunk << id
+            current_duration += duration
+          else
+            chunks << current_chunk.join("+")
+            current_chunk = [id]
+            current_duration = duration
+          end
+        end
+        chunks << current_chunk.join("+") unless current_chunk.empty?
+      end
+
+      chunks
+    end
 
     def reset_rspec_state!
       RSpec.clear_examples
@@ -248,6 +306,24 @@ module RSpecQ
       # we don't want an error that occured outside of the examples (which
       # would set this to `true`) to stop the worker
       RSpec.world.wants_to_quit = false
+
+      # RSpec.clear_examples calls world.reset which clears world.example_groups,
+      # but NOT world.filtered_examples. That hash is keyed by example group
+      # class objects, so old group classes from the previous job remain
+      # referenced as hash keys and cannot be GC'd.
+      RSpec.world.filtered_examples.clear
+
+      # The shared example group registry is also never cleared by world.reset.
+      # When a spec file defines shared_examples/shared_context inside a
+      # describe block, the example group CLASS becomes a key in the registry's
+      # internal hash. Each `load` of a spec file creates new group classes
+      # that get pinned as hash keys, preventing GC of the entire class tree
+      # (including onceler Marshal blobs). We clear per-group entries but
+      # preserve top-level (:main) shared examples from support files, which
+      # are loaded once via `require` and won't be re-defined.
+      RSpec.world.shared_example_group_registry
+           .send(:shared_example_groups)
+           .reject! { |k, _| k != :main }
     end
 
     # NOTE: RSpec has to load the files before we can split them as individual

--- a/test/test_e2e.rb
+++ b/test/test_e2e.rb
@@ -109,7 +109,8 @@ class TestEndToEnd < RSpecQTest
     assert queue.build_successful?
     refute_empty queue.timings
 
-    queue = exec_build("spec_file_splitting", "--file-split-threshold 1")
+    # chunk-target-duration=0 disables chunking so each example stays its own job
+    queue = exec_build("spec_file_splitting", "--file-split-threshold 1 --chunk-target-duration 0")
 
     assert queue.build_successful?
     refute_empty queue.timings
@@ -118,6 +119,27 @@ class TestEndToEnd < RSpecQTest
       "./spec/slow_spec.rb[1:1]",
       "./spec/fast_spec.rb",
     ], queue)
+  end
+
+  def test_spec_file_splitting_with_chunks
+    queue = exec_build("spec_file_splitting", "--update-timings")
+    assert queue.build_successful?
+    refute_empty queue.timings
+
+    # chunk-target-duration=2 groups both slow_spec.rb examples (~1.2s total) into one chunk
+    queue = exec_build("spec_file_splitting", "--file-split-threshold 1 --chunk-target-duration 2")
+
+    assert queue.build_successful?
+
+    processed = queue.processed_jobs
+    assert_equal 2, processed.size, "Expected 2 jobs: 1 chunk + fast_spec.rb"
+    assert processed.any? { |j| j == "./spec/fast_spec.rb" }
+
+    chunk_job = processed.find { |j| j.include?("+") }
+    refute_nil chunk_job, "Expected a chunk job with '+' delimiter"
+    parts = chunk_job.split("+")
+    assert_equal 2, parts.size
+    assert parts.all? { |p| p.start_with?("./spec/slow_spec.rb[") }
   end
 
   def test_suite_with_failures_and_fail_fast

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -30,9 +30,11 @@ class TestScheduling < RSpecQTest
     assert_queue_well_formed(worker.queue)
 
     # 1st run with timings, the slow file will be split
+    # chunk_target_duration=0 keeps each example as its own job (no chunking)
     worker = new_worker("scheduling")
     worker.populate_timings = true
     worker.file_split_threshold = 0.2
+    worker.chunk_target_duration = 0
     silent { worker.work }
 
     assert_queue_well_formed(worker.queue)
@@ -47,6 +49,7 @@ class TestScheduling < RSpecQTest
     worker = new_worker("scheduling")
     worker.populate_timings = true
     worker.file_split_threshold = 0.2
+    worker.chunk_target_duration = 0  # 0 disables chunking (each example is its own job)
     silent { worker.try_publish_queue!(worker.queue) }
 
     assert_equal [
@@ -54,6 +57,49 @@ class TestScheduling < RSpecQTest
       "./test/sample_suites/scheduling/spec/foo_spec.rb[1:1]",
       "./test/sample_suites/scheduling/spec/bar_spec.rb",
     ], worker.queue.unprocessed_jobs
+  end
+
+  def test_time_balanced_chunks
+    # 1st run: no splitting, records file-level timing for foo_spec.rb (~0.3s)
+    worker = new_worker("scheduling")
+    worker.populate_timings = true
+    silent { worker.work }
+
+    assert_queue_well_formed(worker.queue)
+
+    # 2nd run: split + chunk; target=1s groups both examples into one chunk
+    worker = new_worker("scheduling")
+    worker.populate_timings = true
+    worker.file_split_threshold = 0.2
+    worker.chunk_target_duration = 1
+    silent { worker.work }
+
+    assert_queue_well_formed(worker.queue)
+
+    # Both examples from foo_spec.rb are combined into a single chunk job
+    processed = worker.queue.processed_jobs
+    assert_equal 2, processed.size, "Expected 2 jobs: 1 chunk + bar_spec.rb"
+    assert processed.any? { |j| j.include?("+") }, "Expected at least one chunk job"
+    assert processed.any? { |j| j == "./test/sample_suites/scheduling/spec/bar_spec.rb" }
+
+    chunk_job = processed.find { |j| j.include?("+") }
+    parts = chunk_job.split("+")
+    assert_equal 2, parts.size, "Chunk should contain both examples from foo_spec.rb"
+    assert parts.all? { |p| p.start_with?("./test/sample_suites/scheduling/spec/foo_spec.rb[") }
+
+    # 3rd run: per-example timings now in Redis; verify ordering within chunk
+    worker = new_worker("scheduling")
+    worker.populate_timings = true
+    worker.file_split_threshold = 0.2
+    worker.chunk_target_duration = 1
+    silent { worker.try_publish_queue!(worker.queue) }
+
+    unprocessed = worker.queue.unprocessed_jobs
+    assert_equal 2, unprocessed.size
+    # The chunk (slowest total ~0.3s) should be scheduled before bar_spec.rb
+    assert unprocessed.first.include?("+"), "Chunk job should be scheduled first"
+    # Within the chunk, the slowest example [1:2:1] (~0.2s) should come first
+    assert unprocessed.first.start_with?("./test/sample_suites/scheduling/spec/foo_spec.rb[1:2:1]")
   end
 
   def test_untimed_jobs_scheduled_in_the_middle
@@ -87,6 +133,7 @@ class TestScheduling < RSpecQTest
 
     worker = new_worker("deprecation_warning")
     worker.file_split_threshold = 0.2
+    worker.chunk_target_duration = 0  # 0 disables chunking (each example is its own job)
     silent { worker.work }
 
     assert_queue_well_formed(worker.queue)


### PR DESCRIPTION
When a spec file exceeds file_split_threshold, rspecq splits it into individual example jobs. Each job calls Kernel.load on the entire file, and a Ruby GC bug (Zeitwerk's require wrapper prevents collection of anonymous classes) causes ~15MB leaked per load. For a file with 1,266 examples this means ~19GB leaked, causing OOM kills.

This commit groups split examples into time-balanced chunks targeting a configurable duration (default 30s). Each chunk runs multiple examples in a single Kernel.load, reducing loads from ~1,266 to ~10-20 and memory leakage from ~19GB to ~150-300MB.

Changes:
- Add build_time_balanced_chunks to worker.rb using greedy bin-packing sorted by per-example timing (slowest first)
- Chunk jobs use "+" delimiter (e.g. spec.rb[1:1]+spec.rb[1:2])
- JobTimingRecorder records per-example timings for chunk jobs to improve rebalancing on subsequent runs
- Add --chunk-target-duration CLI option and RSPECQ_CHUNK_TARGET_DURATION env var (default: 30)
- Add recover_own_job to Queue so restarted workers recover jobs abandoned by a previous crash instead of losing them
- Clear filtered_examples and shared_example_group_registry between jobs to reduce GC-pinned class accumulation
- Update existing tests with chunk_target_duration=0 to preserve individual-example assertions
- Add test_time_balanced_chunks and test_spec_file_splitting_with_chunks